### PR TITLE
Add cache support (closes #15)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3156,6 +3156,11 @@
         }
       }
     },
+    "idb": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-4.0.5.tgz",
+      "integrity": "sha512-P+Fk9HT2h1DhXoE1YNK183SY+CRh2GHNh28de94sGwhe0bUA75JJeVJWt3SenE5p0BXK7maflIq29dl6UZHrFw=="
+    },
     "ieee754": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     ]
   },
   "dependencies": {
+    "idb": "^4.0.5",
     "js-clipper": "^1.0.1",
     "leaflet": "^1.2.0"
   },


### PR DESCRIPTION
This is my attempt at https://github.com/GuillaumeAmat/leaflet-overpass-layer/issues/15.

I have not rebuilt the bundle because of https://github.com/GuillaumeAmat/leaflet-overpass-layer/issues/29.

If the `cacheEnabled` option is set, it will add the result of each request to the database and when reloading the page, it will fetch the stored results before starting the initial request.