### PR TITLE
Fix remove, clean up all resources created on add

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -6,10 +6,15 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.5/leaflet.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
+        integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
+        crossorigin=""/>
     <link rel="stylesheet" href="../dist/OverPassLayer.css" />
 
-    <script src="http://cdn.leafletjs.com/leaflet-0.7.5/leaflet-src.js"></script>
+    <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"
+       integrity="sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA=="
+       crossorigin=""></script>
+
     <script src="../dist/OverPassLayer.bundle.js"></script>
 
     <style>
@@ -36,11 +41,11 @@
             attribution: [attr_osm, attr_overpass].join(', ')
         });
 
-        var map = new L.Map('map').addLayer(osm).setView(new L.LatLng(44.82921, -0.5834), 14);
+        var map = new L.Map('map').addLayer(osm).setView(new L.LatLng(44.82921, -0.5834), 15);
 
         var opl = new L.OverPassLayer({
             debug: true,
-            endPoint: 'http://overpass.osm.rambler.ru/cgi/',
+            endPoint: 'https://lz4.overpass-api.de/api/',
             query: 'node({{bbox}})["amenity"="post_box"];out;',
             minZoomIndicatorOptions: {
                 position: 'topright',

--- a/src/MinZoomIndicator.js
+++ b/src/MinZoomIndicator.js
@@ -81,16 +81,12 @@ const MinZoomIndicator = L.Control.extend({
   },
 
   onRemove(map) {
-    L.Control.prototype.onRemove.call(this, map);
-
     map.off(
       {
         moveend: this._updateBox
       },
       this
     );
-
-    this._map = null;
   }
 });
 

--- a/src/OverPassLayer.js
+++ b/src/OverPassLayer.js
@@ -414,11 +414,26 @@ const OverPassLayer = L.FeatureGroup.extend({
   onRemove(map) {
     L.LayerGroup.prototype.onRemove.call(this, map);
 
+    if (this.options.minZoomIndicatorEnabled === true) {
+      if (this._map.zoomIndicator) {
+        this._zoomControl._removeLayer(this);
+        this._map.removeControl(this._zoomControl);
+        this._zoomControl = null;
+
+        this._map.zoomIndicator = null;
+      }
+    }
+
+    if (this.options.debug) {
+      this._map.removeLayer(this._requestBoxes);
+      this._map.removeLayer(this._responseBoxes);
+    }
+
     this._resetData();
 
-    map.off('moveend', this._prepareRequest, this);
+    this._map.removeLayer(this._markers);
 
-    this._map = null;
+    this._map.off('moveend', this._prepareRequest, this);
   },
 
   setQuery(query) {


### PR DESCRIPTION
- Fix remove logic not working correctly with recent version of Leaflet and clean up all resources during `onRemove()` that were created in `onAdd()`
- Update leaflet in demo
- Fix Overpass endpoint in demo

Tried with `Leaflet 1.7.1` release, did not try on previous versions.
If it is necessary to support older versions, what is the minimal supported version?